### PR TITLE
Change tool_choice to support multiple tools and result formatting.

### DIFF
--- a/pydantic_ai_bedrock/bedrock.py
+++ b/pydantic_ai_bedrock/bedrock.py
@@ -279,14 +279,12 @@ class BedrockAgentModel(AgentModel):
         stream: bool,
         model_settings: ModelSettings | None,
     ) -> ConverseResponseTypeDef | EventStream[ConverseStreamOutputTypeDef]:
-        if not self.tools:
+        if not self.tools or not self.support_tools_choice:
             tool_choice: None = None
-        elif not self.allow_text_result and self.support_tools_choice:
-            tool_choice = {
-                "tool": {"name": tool_type_def["toolSpec"]["name"]} for tool_type_def in self.tools
-            }
+        elif not self.allow_text_result:
+            tool_choice = {'any': {}}
         else:
-            tool_choice = None
+            tool_choice = {'auto': {}}
 
         system_prompt, bedrock_messages = self._map_message(messages)
         inference_config = self._map_inference_config(model_settings)

--- a/pydantic_ai_bedrock/bedrock.py
+++ b/pydantic_ai_bedrock/bedrock.py
@@ -282,9 +282,9 @@ class BedrockAgentModel(AgentModel):
         if not self.tools or not self.support_tools_choice:
             tool_choice: None = None
         elif not self.allow_text_result:
-            tool_choice = {'any': {}}
+            tool_choice = {"any": {}}
         else:
-            tool_choice = {'auto': {}}
+            tool_choice = {"auto": {}}
 
         system_prompt, bedrock_messages = self._map_message(messages)
         inference_config = self._map_inference_config(model_settings)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I had a problem when calling tools and returning formatted results. When using Claude the tools seemed to be ignored and just the formatted results were returned. I tweaked how the `_messages_created` method handled the tool_choice formatting to more align with the documentation at https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I was not able to use Bedrock Claude with tools and formatted results. This allows multiple tools to be chosen by the LLM instead of forcing one tool (the result formatting tool) when multiple tools are provided.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested with multiple versions of Claude adding multiple tools and result_type to the agent.

<!--- Include details of your testing environment, tests ran to see how -->
Python 3.12.8
<!--- your change affects other areas of the code, etc. -->
Will no longer force a single tool_choice.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
