### PR TITLE
Add missing property decorator

### DIFF
--- a/pydantic_ai_bedrock/bedrock.py
+++ b/pydantic_ai_bedrock/bedrock.py
@@ -140,6 +140,7 @@ class BedrockStreamedResponse(StreamedResponse):
                         tool_call_id=tool_id,
                     )
 
+    @property
     def timestamp(self) -> datetime:
         return self._timestamp
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add missing `@property` decorator to the `timestamp` field in the BedrockStreamedResult class, which subclasses `StreamedRunResult` which defines `timestamp` as a property:

https://github.com/pydantic/pydantic-ai/blob/2f2713bc529f33be6177396ee1328fca4ba24f5f/pydantic_ai_slim/pydantic_ai/models/__init__.py#L260-L264

## Motivation and Context

Fixing a bug when using `Agent.run_stream` and trying to access the timestamp property.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, tests ran to see how -->

<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Repro:

```python
import asyncio
from pydantic_ai import Agent
from pydantic_ai_bedrock.bedrock import BedrockModel
from pydantic_ai.models.test import TestModel
from datetime import datetime


async def main():
    """Main entrypoint."""
    model = BedrockModel("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
    # model = TestModel()
    agent = Agent(model=model, system_prompt="You are a chatbot")

    async with agent.run_stream("what is 2+2?") as result:
        async for text in result.stream(debounce_by=0.01):
            print(
                result.timestamp,
                type(result.timestamp),
            )
            assert isinstance(result.timestamp(), datetime)
            await asyncio.sleep(0.01)


if __name__ == "__main__":
    asyncio.run(main())
```

If you swap the `BedrockModel` with the `TestModel` (or any other model cls, really) the assertion passes
